### PR TITLE
Remember the penalty of the substituted player

### DIFF
--- a/src/controller/action/ui/Robot.java
+++ b/src/controller/action/ui/Robot.java
@@ -14,6 +14,7 @@ import controller.action.ui.penalty.PickUpHL;
 import controller.action.ui.penalty.ServiceHL;
 import controller.action.ui.penalty.Substitute;
 import data.AdvancedData;
+import data.AdvancedData.PenaltyQueueData;
 import data.HL;
 import data.PlayerInfo;
 import data.Rules;
@@ -55,7 +56,7 @@ public class Robot extends GCAction
     {
         PlayerInfo player = data.team[side].player[number];
         if (player.penalty == PlayerInfo.PENALTY_SUBSTITUTE) {
-            ArrayList<Long> playerInfoList = data.penaltyQueueForSubPlayers.get(side); 
+            ArrayList<PenaltyQueueData> playerInfoList = data.penaltyQueueForSubPlayers.get(side);
             if (playerInfoList.isEmpty()){
                 if (Rules.league instanceof HL) {
                     player.penalty = PlayerInfo.PENALTY_NONE;
@@ -64,14 +65,14 @@ public class Robot extends GCAction
                 }
                 data.whenPenalized[side][number] = data.getTime();
             } else {
-                Long playerInfo = playerInfoList.get(0);
+                PenaltyQueueData playerInfo = playerInfoList.get(0);
                 if (Rules.league instanceof HL) {
-                    player.penalty = PlayerInfo.PENALTY_HL_PICKUP_OR_INCAPABLE;
+                    player.penalty = playerInfo.penalty;
                 } else {
                     player.penalty = PlayerInfo.PENALTY_SPL_REQUEST_FOR_PICKUP;
                 }
-                
-                data.whenPenalized[side][number] = playerInfo;
+
+                data.whenPenalized[side][number] = playerInfo.whenPenalized;
                 playerInfoList.remove(0);
             }
             Log.state(data, "Entering Player " + Rules.league.teamColorName[data.team[side].teamColor]

--- a/src/controller/action/ui/penalty/Substitute.java
+++ b/src/controller/action/ui/penalty/Substitute.java
@@ -27,7 +27,7 @@ public class Substitute extends Penalty
     public void performOn(AdvancedData data, PlayerInfo player, int side, int number)
     {
         if(player.penalty != PlayerInfo.PENALTY_NONE){
-            data.penaltyQueueForSubPlayers.get(side).add(data.whenPenalized[side][number]);
+            data.addToPenaltyQueue(side, data.whenPenalized[side][number], player.penalty);
         }
         
         player.penalty = PlayerInfo.PENALTY_SUBSTITUTE;

--- a/src/data/AdvancedData.java
+++ b/src/data/AdvancedData.java
@@ -5,6 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 
 import controller.action.ActionBoard;
@@ -85,7 +86,8 @@ public class AdvancedData extends GameControlData implements Cloneable
     public byte previousSecGameState = STATE2_NORMAL;
 
     /** Keeps the penalties for the players if there are substituted */
-    public ArrayList<ArrayList<Long>> penaltyQueueForSubPlayers = new ArrayList<ArrayList<Long>>();
+    public ArrayList<ArrayList<PenaltyQueueData>> penaltyQueueForSubPlayers = new ArrayList<ArrayList<PenaltyQueueData>>();
+
     /** Keep the timestamp when a coach message was received*/
     public long timestampCoachPackage[] = {0, 0};
     /** Keep the coach messages*/
@@ -104,10 +106,10 @@ public class AdvancedData extends GameControlData implements Cloneable
                     team[i].player[j].penalty = PlayerInfo.PENALTY_SUBSTITUTE;
                 }
             }
-            penaltyQueueForSubPlayers.add(new ArrayList<Long>());
+            penaltyQueueForSubPlayers.add(new ArrayList<PenaltyQueueData>());
         }
     }
-    
+
     /**
      * Generically clone this object. Everything referenced must be Serializable.
      * @return A deep copy of this object.
@@ -371,4 +373,19 @@ public class AdvancedData extends GameControlData implements Cloneable
             }
         }
     }
+
+    public class PenaltyQueueData  implements Serializable {
+        public long whenPenalized;
+        public byte penalty;
+
+        public PenaltyQueueData(long whenPenalized, byte penalty) {
+            this.whenPenalized = whenPenalized;
+            this.penalty = penalty;
+        }
+    }
+
+    public void addToPenaltyQueue(int side, long whenPenalized, byte penalty) {
+        penaltyQueueForSubPlayers.get(side).add(new PenaltyQueueData(whenPenalized, penalty));
+    }
+
 }


### PR DESCRIPTION
When substituting a player, the substituting player should keep the remaining penalty time of the substituted player. In the humanoid league there are two different penalty times (60s for service, and 30s for all other penalties) which requires that the type of penalty is remembered to correctly calculate the remaining time.

I do not know how this applies to the SPL, i.e. whether the substituting player's penalty type should always be PICKUP and not whatever the substituted player's penalty actually was.
