### PR TITLE
StartInput window size correction

### DIFF
--- a/src/controller/ui/StartInput.java
+++ b/src/controller/ui/StartInput.java
@@ -249,10 +249,7 @@ public class StartInput extends JFrame implements Serializable
                 
         league.getActionListeners()[league.getActionListeners().length - 1].actionPerformed(null);
 
-        int size = teamContainer[0].getPreferredSize().width + teamContainer[1].getPreferredSize().width;
-        size = Math.max(size, team[0].getPreferredSize().width + team[1].getPreferredSize().width);
-
-        getContentPane().setPreferredSize(new Dimension(size, WINDOW_HEIGHT));
+        getContentPane().setPreferredSize(new Dimension(WINDOW_WIDTH, WINDOW_HEIGHT));
         pack();
         setVisible(true);
     }


### PR DESCRIPTION
I use a hidpi display where the window border is bigger than in a normal setup. The StartInpt window is broken because the size is set for the window and not for the content panel. The window size also contain the window border so content panel + window borer = window size. After this fix the StartInput window is useable again.
