### PR TITLE
differentiate between sending and listening port

### DIFF
--- a/src/controller/Main.java
+++ b/src/controller/Main.java
@@ -156,14 +156,14 @@ public class Main
             //receiver
             GameControlReturnDataReceiver receiver = GameControlReturnDataReceiver.getInstance();
             receiver.start();
-            
+
             if (Rules.league.isCoachAvailable) {
                 SPLCoachMessageReceiver spl = SPLCoachMessageReceiver.getInstance();
                 spl.start();
             }
         } catch (Exception e) {
             JOptionPane.showMessageDialog(null,
-                    "Error while setting up GameController on port: " + GameControlData.GAMECONTROLLER_PORT + ".",
+                    "Error while setting up GameController on port: " + GameControlData.GAMECONTROLLER_RETURNDATA_PORT + ".",
                     "Error on configured port",
                     JOptionPane.ERROR_MESSAGE);
             System.exit(-1);

--- a/src/controller/net/GameControlReturnDataReceiver.java
+++ b/src/controller/net/GameControlReturnDataReceiver.java
@@ -17,7 +17,7 @@ import data.GameControlReturnData;
  *
  * @author Marcel Steinbeck
  *
- * This class is used to receive a packe send by a robot on port {@link GameControlData#GAMECONTROLLER_PORT} via UDP
+ * This class is used to receive a packet send by a robot on port {@link GameControlData#GAMECONTROLLER_RETURNDATA_PORT} via UDP
  * over broadcast.
  * If a package was received, this class will invoke {@link RobotWatcher#update(data.GameControlReturnData)} to update
  * the robots online status.
@@ -42,7 +42,7 @@ public class GameControlReturnDataReceiver extends Thread
         datagramSocket = new DatagramSocket(null);
         datagramSocket.setReuseAddress(true);
         datagramSocket.setSoTimeout(500);
-        datagramSocket.bind(new InetSocketAddress(GameControlData.GAMECONTROLLER_PORT));
+        datagramSocket.bind(new InetSocketAddress(GameControlData.GAMECONTROLLER_RETURNDATA_PORT));
     }
 
     /**

--- a/src/controller/net/Sender.java
+++ b/src/controller/net/Sender.java
@@ -11,7 +11,7 @@ import java.net.*;
  * @author Marcel Steinbeck
  *
  * This class is used to send the current {@link GameControlData} (game-state) to all robots every 500 ms.
- * The package will be send via UDP on port {@link GameControlData#GAMECONTROLLER_PORT} over broadcast.
+ * The package will be send via UDP on port {@link GameControlData#GAMECONTROLLER_GAMEDATA_PORT} over broadcast.
  *
  * To prevent race-conditions (the sender is executed in its thread-context), the sender will hold a deep copy
  * of {@link GameControlData} (have a closer look to the copy-constructor
@@ -100,7 +100,7 @@ public class Sender extends Thread
                 data.updateTimes();
                 data.packetNumber = packetNumber;
                 byte[] arr = data.toByteArray().array();
-                DatagramPacket packet = new DatagramPacket(arr, arr.length, group, GameControlData.GAMECONTROLLER_PORT);
+                DatagramPacket packet = new DatagramPacket(arr, arr.length, group, GameControlData.GAMECONTROLLER_GAMEDATA_PORT);
 
                 try {
                     datagramSocket.send(packet);

--- a/src/data/GameControlData.java
+++ b/src/data/GameControlData.java
@@ -15,7 +15,8 @@ import java.nio.ByteOrder;
 public class GameControlData implements Serializable
 {
     /** Some constants from the C-structure. */
-    public static final int GAMECONTROLLER_PORT = 3838;
+    public static final int GAMECONTROLLER_RETURNDATA_PORT = 3838; // port to receive return-packets on
+    public static final int GAMECONTROLLER_GAMEDATA_PORT= 3838; // port to send game state packets to
 
     public static final String GAMECONTROLLER_STRUCT_HEADER = "RGme";
     public static final byte GAMECONTROLLER_STRUCT_VERSION = 8;

--- a/src/visualizer/Listener.java
+++ b/src/visualizer/Listener.java
@@ -32,9 +32,9 @@ public class Listener extends Thread
             datagramSocket = new DatagramSocket(null);
             datagramSocket.setReuseAddress(true);
             datagramSocket.setSoTimeout(500);
-            datagramSocket.bind(new InetSocketAddress(GameControlData.GAMECONTROLLER_PORT));
+            datagramSocket.bind(new InetSocketAddress(GameControlData.GAMECONTROLLER_GAMEDATA_PORT));
         } catch (SocketException e) {
-            Log.error("Error on start listening to port " + GameControlData.GAMECONTROLLER_PORT);
+            Log.error("Error on start listening to port " + GameControlData.GAMECONTROLLER_GAMEDATA_PORT);
             System.exit(1);
         }
     }
@@ -56,7 +56,7 @@ public class Listener extends Thread
                 }
             } catch (SocketTimeoutException e) { // ignore, because we set a timeout
             } catch (IOException e) {
-                Log.error("Error while listening to port " + GameControlData.GAMECONTROLLER_PORT);
+                Log.error("Error while listening to port " + GameControlData.GAMECONTROLLER_GAMEDATA_PORT);
             }
         }
     }


### PR DESCRIPTION
For local testing it can be very helpful to have the gamecontroller send and
receive data on two different ports. Ideally this can be set via the command
line, however for now the GameControlData class constants can be adjusted.
