### PR TITLE
set date/time formatter to UTC

### DIFF
--- a/src/controller/ui/GUI.java
+++ b/src/controller/ui/GUI.java
@@ -14,6 +14,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 import javax.swing.AbstractButton;
 import javax.swing.ButtonGroup;
@@ -264,6 +265,10 @@ public class GUI extends JFrame implements GCGUI
         super(WINDOW_TITLE);
         setSize(WINDOW_WIDTH, WINDOW_HEIGHT);
         setResizable(true);
+
+        // set timezone of formatter to UTC
+        clockFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
         GraphicsDevice gd = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
         int width = gd.getDisplayMode().getWidth();
         int height = gd.getDisplayMode().getHeight();


### PR DESCRIPTION
The formatter uses the local time zone. If this timezone has an offset of
non-full hours (e.g. Tehran, which is GMT+0330), the time displayed is always
off (in case of Tehran, it will display 40 minute game time)
