### PR TITLE
Fix buffer size for forwarded GameControlReturnData packages

### DIFF
--- a/src/common/net/GameControlReturnDataReceiver.java
+++ b/src/common/net/GameControlReturnDataReceiver.java
@@ -66,7 +66,7 @@ public class GameControlReturnDataReceiver extends Thread {
         @Override
         public void run() {
             while (!isInterrupted()) {
-                final byte[] buffer = new byte[GameControlReturnData.SIZE];
+                final byte[] buffer = new byte[GameControlReturnData.SIZE + (forwarded ? 4 : 0)];
                 final DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
 
                 try {


### PR DESCRIPTION
Forwarded packets are 4 bytes larger to contain the address. If the buffer is not expanded all forwarded messages are marked invalid in the TCM, because it fails to extract the last field.