### PR TITLE
Fix for picking VM network adaptor on Windows

### DIFF
--- a/src/controller/GameController.java
+++ b/src/controller/GameController.java
@@ -218,6 +218,7 @@ public class GameController {
             if (networkInterface == null || !networkInterface.isUp()) {
                 Enumeration<NetworkInterface> nifs = NetworkInterface.getNetworkInterfaces();
                 if (interfaceName.isEmpty()) {
+                    outer:
                     while (nifs.hasMoreElements()) {
                         NetworkInterface nif = nifs.nextElement();
                         if (!nif.isUp() || nif.isLoopback()) {
@@ -230,6 +231,9 @@ public class GameController {
                             } else if (ifAddress.getAddress() instanceof Inet4Address) {
                                 networkInterface = nif;
                                 localAddress = ifAddress;
+                                if (System.getProperty("os.name").contains("Windows")){
+                                    break outer;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
When running GameController on a Windows PC with a Virtual Machine installed, localAddress is incorrectly set to the VM's ifAddress.

To fix this, we can check if the OS is Windows and break the outer while loop after the first localAddress is set. 

This set localAddress correctly on Windows, while not affecting other OSs.